### PR TITLE
Move onPageSelected/onMomentumScrollEnd functionality…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,12 @@ export default class SwipeALot extends Component {
           x: page * width
         })
       }
+
+      this.onSetActivePage(page)
+      if (this.getAutoplaySettings().disableOnSwipe &&
+        this.autoplayPageCurrentlyBeingTransitionedTo !== page) {
+        this.stopAutoplay()
+      }
     }
 
     this.emitter.addListener('swipeToPage', this.swipeToPageListener)
@@ -105,12 +111,6 @@ export default class SwipeALot extends Component {
 
   swipeToPage(page) {
     this.emitter.emit('swipeToPage', { page })
-
-    this.onSetActivePage(page)
-    if (this.getAutoplaySettings().disableOnSwipe &&
-      this.autoplayPageCurrentlyBeingTransitionedTo !== page) {
-      this.stopAutoplay()
-    }
   }
 
   static get propTypes() {
@@ -143,11 +143,6 @@ export default class SwipeALot extends Component {
                 removeClippedSubviews={true}
                 showsHorizontalScrollIndicator={false}
                 showsVerticalScrollIndicator={false}
-                onMomentumScrollEnd={(e) => {
-                  const { width } = this.store.getState()
-                  const page = e.nativeEvent.contentOffset.x / width
-                  this.swipeToPage(page)
-                }}
                 onLayout={(event) => {
                   const {x, y, width, height} = event.nativeEvent.layout
                   this.store.dispatch({
@@ -168,9 +163,6 @@ export default class SwipeALot extends Component {
               <ViewPagerAndroid
                 ref={(c) => this.swiper = c}
                 initialPage={0}
-                onPageSelected={(e) => {
-                  this.swipeToPage(e.nativeEvent.position)
-                }}
                 style={{
                   flex: 1
                 }}>


### PR DESCRIPTION
Move onPageSelected/onMomentumScrollEnd functionality to swipeToPageListener because onPageSelected is not being triggered for Android. This functionality is better to be centralized in the swipeToPageListener instead anyway.
